### PR TITLE
Add support for custom resource routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ import { Company, Message } from './app/entities';
 
 @Type()
 @JsonApiResource({
-    type: 'users' // Specify resource type.
+    type: 'user' // Specify resource type.
+    route: 'users' // Custom route for the resource. If not specified, the value of `type` will be used.
 })
 export class User
 {

--- a/src/json-api-entity-provider.ts
+++ b/src/json-api-entity-provider.ts
@@ -379,7 +379,7 @@ export class JsonApiEntityProvider implements EntityProvider
     protected createResourceLinkObject<TEntity extends Entity>(typeMetadata: TypeMetadata<TEntity>): LinkObject
     {
         const jsonApiResourceMetadata = this.jsonApiAdapter.extractJsonApiResourceMetadataOrFail(typeMetadata);
-        const linkObject = `${this.jsonApiConnection.baseUrl}/${jsonApiResourceMetadata.type}`;
+        const linkObject = `${this.jsonApiConnection.baseUrl}/${jsonApiResourceMetadata.route}`;
 
         return linkObject;
     }

--- a/src/json-api-resource-metadata.ts
+++ b/src/json-api-resource-metadata.ts
@@ -50,6 +50,16 @@ export class JsonApiResourceMetadata<TEntity extends Entity>
     }
 
     /**
+     * Gets resource route.
+     * 
+     * @returns {string} Resource route.
+     */
+    public get route(): string
+    {
+        return this.jsonApiResourceOptions.route ?? this.type;
+    }
+
+    /**
      * Gets property name representing id.
      * 
      * @returns {string} Property name representing id.
@@ -71,6 +81,11 @@ export class JsonApiResourceMetadata<TEntity extends Entity>
         if (!isUndefined(jsonApiResourceOptions.type))
         {
             this.jsonApiResourceOptions.type = jsonApiResourceOptions.type;
+        }
+
+        if (!isUndefined(jsonApiResourceOptions.route))
+        {
+            this.jsonApiResourceOptions.route = jsonApiResourceOptions.route;
         }
 
         if (!isUndefined(jsonApiResourceOptions.id))

--- a/src/json-api-resource-options.ts
+++ b/src/json-api-resource-options.ts
@@ -13,6 +13,13 @@ export interface JsonApiResourceOptions
     type?: string;
 
     /**
+     * Resource route as described in specification.
+     * 
+     * @type {string}
+     */
+    route?: string;
+
+    /**
      * Property name representing id if differs from one 
      * described in specification.
      * 


### PR DESCRIPTION
- Not all JSON:API implementation use the exact type name for the resource route. The most common exception is probably using singular type names and plural route names.
- This change allows you to optionally configure a route for each type, which will be used when generating URLs. If no route is specified, it falls back to using the type as before.

# Description

Add a `route` property to `JsonApiResourceOptions` and use it generate resource URLs. Falls back on `type`
 if `route` is undefined.

Fixes #4 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

There aren't any existing tests that deal with custom routes, so for now I have only tested against a private server. Would be happy to discuss how to incorporate tests.

## Checklist before requesting a review

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
