### PR TITLE
Added Json API Relationship Tests (self links)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,86 @@ export class User
 
 After that you have to follow `EntityStore.TS` [documentation](https://github.com/dipscope/EntityStore.TS). Supported methods which you can use through `EntitySet` is dependent from backend implementation of [JSON:API](https://jsonapi.org) specification.
 
+## Relationship Operations
+The JsonApiEntityProvider supplies functionality for simplifying relationship operations.
+
+NOTE: each of these operations assume that all entities are already stored.
+Thus, operations to Update/Add models will have to performed after adding the related model to the entity set.
+```typescript
+const specEntityStore = new SpecEntityStore();
+const userSet = specEntityStore.userSet;
+const messageSet = specEntityStore.messageSet;
+const companySet = specEntityStore.companySet;
+const jsonApiEntityProvider = specEntityStore.jsonApiEntityProvider;
+// Populate entityset
+const user = await userSet.add(user);
+const company = await companySet.add(new Company())
+const company2 = await companySet.add(new Company())
+const newMessage = await messageSet.add(new Message())
+const newMessages = await messageSet.bulkAdd([
+    new Message(),
+    new Message()
+])
+// now perform relationship operations
+```
+
+### To One Relationship Provider
+The To One relationship provider enables operations on to-one relationships.
+ToOne Relationship Provider currently only provides support for the followin features:
+1. Fetching related data
+2. Updating related data (pointing relationship to a different model)
+3. Removing related data
+```typescript
+const userCompany = jsonApiEntityProvider.createJsonApiToOneRelationship(userSet, user, u => u.company);
+
+// Fetching ToOne Relationship data
+const company = await userCompany.find();
+
+// Updating ToOne Relationship data
+await userCompany.update(company2);
+
+// Removing ToOne Relationship data
+await userCompany.remove();
+```
+
+### To Many Relationshp Provider
+The To Many relationship provider enables operations on to-many relationships.
+ToMany Relationship Provider currently only provides support for the followin features:
+1. Fetching related data
+2. Fetching related data with include and sort clauses
+3. Fetching related data with pagination
+3. Adding an element to the related data
+2. Updating related data (pointing relationship to a different model)
+3. Removing an element from the related data
+```typescript
+const userMessages = jsonApiEntityProvider.createJsonApiToManyRelationship(userSet, user, u => u.messages);
+
+// Fetching ToOne Relationship data
+const messages = await userMessages.findAll();
+// Fetching related data with include clauses
+const messagesWithUser = await userMessages.include(x => x.user).findAll();
+const messagesWithReplies = await userMessages.includeCollection(x => x.messages).findOne();
+// Fetching related data with sort clauses
+const messagesAsc = await userMessages.sortByAsc(x => x.text).findAll();
+const messagesDesc = await userMessages.sortByDesc(x => x.text).findAll();
+// Fetching related data with pagination clauses
+const firstPageData = await userMessages.paginate(x => x.pageSize(1, 10)).findAll();
+const secondPageData = await userMessages.paginate(x => x.pageSize(2, 10)).findAll();
+const lastPageData = await userMessages.paginate(x => x.pageSize(4, 10)).findAll();
+
+// Adding element(s) to the related data
+await userMessages.add(newMessage);
+await userMessages.bulkAdd(newMessages);
+
+// Updating ToMany Relationship data
+await userMessages.update(addedMessage);
+await userMessages.bulkUpdate(addedMessages);
+
+// Removing ToMany Relationship data
+await userMessages.remove(addedMessage);
+await userMessages.bulkRemove(toRemoveMessages);
+```
+
 ## Versioning
 
 We use [SemVer](http://semver.org) for versioning. For the versions available, see the versions section on [NPM project page](https://www.npmjs.com/package/@dipscope/json-api-entity-provider).

--- a/backend/json-api-net/AppDbContext.cs
+++ b/backend/json-api-net/AppDbContext.cs
@@ -38,6 +38,11 @@ namespace JsonApiNet
                 .WithMany(u => u.Messages)
                 .HasForeignKey(m => m.UserId);
 
+            modelBuilder.Entity<Message>()
+                .HasOne(m => m.Parent)
+                .WithMany(p => p.Messages)
+                .HasForeignKey(m => m.MessageId);
+
             return;
         }
     }

--- a/backend/json-api-net/Message.cs
+++ b/backend/json-api-net/Message.cs
@@ -11,6 +11,14 @@ namespace JsonApiNet
 
         [HasOne]
         public User? User { get; set; }
+
+        [HasOne]
+        public Message? Parent { get; set; }
+
+        [HasMany]
+        public IList<Message>? Messages { get; set; }
+
         public int? UserId { get; set; }
+        public int? MessageId { get; set; }
     }
 }

--- a/backend/json-api-net/User.cs
+++ b/backend/json-api-net/User.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using JsonApiDotNetCore.Resources;
 using JsonApiDotNetCore.Resources.Annotations;
 
@@ -21,6 +22,7 @@ namespace JsonApiNet
         public int? CompanyId { get; set; }
 
         [HasMany]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public IList<Message> Messages { get; set; }
     }
 }

--- a/spec/entity-store.spec.ts
+++ b/spec/entity-store.spec.ts
@@ -57,12 +57,19 @@ export class Message extends JsonApiEntity
     @Property(String) public text: string;
     @Property(() => User) public user: User;
 
-    public constructor(@Inject('text') text: string, @Inject('user') user: User)
+    // Let's make it so that messages are replyable
+    // let a reply be defined as a message which has a 'parent'
+    // This will make testing more robust, as messages will posses a toOne and a toMany relationship.
+    @Property(() => Message) public parent?: Message;
+    @Property(Array, [() => Message]) public messages!: Message[];
+
+    public constructor(@Inject('text') text: string, @Inject('user') user: User, @Inject('parent') parent?: Message)
     {
         super();
 
         this.text = text;
         this.user = user;
+        this.parent = parent;
 
         return;
     }

--- a/spec/json-api-to-many-relationship-provider.spec.ts
+++ b/spec/json-api-to-many-relationship-provider.spec.ts
@@ -2,14 +2,16 @@ import { EntitySet } from '@dipscope/entity-store';
 import { generateRandomString, Message, SpecEntityStore, User } from './entity-store.spec';
 import { JsonApiToManyRelationship } from '../src';
 
-async function addUser(userSet: EntitySet<User>, name?: string) {
+async function addUser(userSet: EntitySet<User>, name?: string) 
+{
     name ??= generateRandomString();
     const user = new User(name, 1);
     const remoteUser = await userSet.add(user);
     expect(remoteUser).toBe(user);
     return remoteUser;
 }
-async function setupRelationshipTest() {
+async function setupRelationshipTest() 
+{
     // Get Entity Store Objects
     const specEntityStore = new SpecEntityStore();
     const userSet = specEntityStore.userSet;
@@ -29,19 +31,23 @@ async function setupRelationshipTest() {
     return { specEntityStore, userSet, messageSet, jsonApiEntityProvider, user, userMessages, addedMessages, setupCount }
 }
 
-function createMessage(user: User, text?: string) {
+function createMessage(user: User, text?: string) 
+{
     text ??= generateRandomString();
     return new Message(text, user);
 }
 
-async function getCurrentMessageCount(relationship: JsonApiToManyRelationship<User, Message>) {
+async function getCurrentMessageCount(relationship: JsonApiToManyRelationship<User, Message>) 
+{
     const elements = await relationship.findAll();
     return elements.length;
 }
 
-describe('Json api to many relationship provider', () => {
-    it('should fetch existing entities', async () => {
-        const { userSet, messageSet, userMessages, addedMessages, setupCount } = await setupRelationshipTest();
+describe('Json api to many relationship provider', () => 
+{
+    it('should fetch existing entities', async () =>
+    {
+        const { userSet, messageSet, userMessages, addedMessages, user, setupCount } = await setupRelationshipTest();
         // This is a pre-check for validating that setup was ran correctly
         const initialCount = await getCurrentMessageCount(userMessages);
         expect(initialCount).toBe(setupCount);
@@ -57,11 +63,23 @@ describe('Json api to many relationship provider', () => {
         const finalData = await userMessages.findAll();
         expect(finalData.length).toBe(initialCount);
         // Let's also check that our queried data is correct
-        for (let i = 0; i < setupCount; i++) {
-            expect(finalData.at(i)).toBe(addedMessages.at(i));
+        // Sort Data
+        const sortedFinalData = finalData.sort((a, b) => (a.text > b.text ? -1 : 1))
+        const sortedMessages = addedMessages.sort((a, b) => (a.text > b.text ? -1 : 1))
+        for (let i = 0; i < setupCount; i++)
+        {
+            const actual = sortedFinalData.at(i);
+            const expected = sortedMessages.at(i);
+            if (actual && expected)
+            {
+                actual.user = user;
+                expected.user = user;
+            }
+            expect(actual).toEqual(expected);
         }
     });
-    it('should add new entities', async () => {
+    it('should add new entities', async () =>
+    {
         const { userSet, messageSet, userMessages, setupCount } = await setupRelationshipTest();
         // This is a pre-check for validating that setup was ran correctly
         const initialCount = await getCurrentMessageCount(userMessages);
@@ -86,7 +104,8 @@ describe('Json api to many relationship provider', () => {
 
     });
 
-    it('should update existing entities', async () => {
+    it('should update existing entities', async () =>
+    {
         const { userSet, messageSet, userMessages, setupCount } = await setupRelationshipTest();
         // This is a pre-check for validating that setup was ran correctly
         const initialCount = await getCurrentMessageCount(userMessages);
@@ -110,7 +129,8 @@ describe('Json api to many relationship provider', () => {
         expect(finalData.length).toBe(1);
     });
 
-    it('should remove existing entities', async () => {
+    it('should remove existing entities', async () =>
+    {
         const { userMessages, addedMessages, setupCount } = await setupRelationshipTest();
         // This is a pre-check for validating that setup was ran correctly
         const initialCount = await getCurrentMessageCount(userMessages);
@@ -119,7 +139,8 @@ describe('Json api to many relationship provider', () => {
         expect(addedMessage).toBeDefined(); // ! Required for code assumptions
 
         // ! Function Under Test ! !
-        if (addedMessage) {
+        if (addedMessage) 
+{
             await userMessages.remove(addedMessage);
         }
 
@@ -128,7 +149,8 @@ describe('Json api to many relationship provider', () => {
         expect(finalData.length).toBe(initialCount - 1);
     });
 
-    it('should bulk add new entities', async () => {
+    it('should bulk add new entities', async () =>
+    {
         const { userSet, messageSet, userMessages, setupCount } = await setupRelationshipTest();
         // This is a pre-check for validating that setup was ran correctly
         const initialCount = await getCurrentMessageCount(userMessages);
@@ -152,7 +174,8 @@ describe('Json api to many relationship provider', () => {
         expect(finalData.length).toBe(initialCount + setupCount);
     });
 
-    it('should bulk update existing entities', async () => {
+    it('should bulk update existing entities', async () =>
+    {
         const { userSet, messageSet, userMessages, setupCount } = await setupRelationshipTest();
         // This is a pre-check for validating that setup was ran correctly
         const initialCount = await getCurrentMessageCount(userMessages);
@@ -176,7 +199,8 @@ describe('Json api to many relationship provider', () => {
         expect(finalData.length).toBe(setupCount - 1);
     });
 
-    it('should bulk remove existing entities', async () => {
+    it('should bulk remove existing entities', async () =>
+    {
         const { userMessages, addedMessages, setupCount } = await setupRelationshipTest();
         // This is a pre-check for validating that setup was ran correctly
         const initialCount = await getCurrentMessageCount(userMessages);
@@ -192,16 +216,17 @@ describe('Json api to many relationship provider', () => {
         expect(finalData.length).toBe(1);
     });
 
-    it('should sort existing entities in ascending order', async () => {
+    it('should sort existing entities in ascending order', async () =>
+    {
         const { user, messageSet, userMessages, setupCount } = await setupRelationshipTest();
         // This is a pre-check for validating that setup was ran correctly
         const initialCount = await getCurrentMessageCount(userMessages);
         expect(initialCount).toBe(setupCount);
 
         // Our random strings will start with an ISO string.
-        const messageA = createMessage(user, "00");
+        const messageA = createMessage(user, '00');
         const addedMessageA = await messageSet.add(messageA);
-        const messageZ = createMessage(user, "ZULU");
+        const messageZ = createMessage(user, 'ZULU');
         const addedMessageZ = await messageSet.add(messageZ);
 
         // ! Function Under Test ! !
@@ -212,16 +237,17 @@ describe('Json api to many relationship provider', () => {
         expect(finalData.last()?.id).toBe(addedMessageZ.id);
     });
 
-    it('should sort existing entities in descending order', async () => {
+    it('should sort existing entities in descending order', async () =>
+    {
         const { user, messageSet, userMessages, setupCount } = await setupRelationshipTest();
         // This is a pre-check for validating that setup was ran correctly
         const initialCount = await getCurrentMessageCount(userMessages);
         expect(initialCount).toBe(setupCount);
 
         // Our random strings will start with an ISO string.
-        const messageA = createMessage(user, "00");
+        const messageA = createMessage(user, '00');
         const addedMessageA = await messageSet.add(messageA);
-        const messageZ = createMessage(user, "ZULU");
+        const messageZ = createMessage(user, 'ZULU');
         const addedMessageZ = await messageSet.add(messageZ);
 
         // ! Function Under Test ! !
@@ -233,7 +259,8 @@ describe('Json api to many relationship provider', () => {
         expect(finalData.last()?.id).toBe(addedMessageA.id);
     });
 
-    it('should include relationships', async () => {
+    it('should include relationships', async () =>
+    {
         const { user, userMessages, setupCount } = await setupRelationshipTest();
         // This is a pre-check for validating that setup was ran correctly
         const initialCount = await getCurrentMessageCount(userMessages);
@@ -245,12 +272,14 @@ describe('Json api to many relationship provider', () => {
         expect(finalData.length).toBe(initialCount);
 
         // Let's also check that our queried data is correct
-        for (let i = 0; i < setupCount; i++) {
+        for (let i = 0; i < setupCount; i++)
+        {
             expect(finalData.at(i)?.user).toBe(user);
         }
     });
 
-    it('should paginate existing entities', async () => {
+    it('should paginate existing entities', async () => 
+    {
         const { user, messageSet, userMessages, setupCount } = await setupRelationshipTest();
         // This is a pre-check for validating that setup was ran correctly
         const initialCount = await getCurrentMessageCount(userMessages);

--- a/spec/json-api-to-many-relationship-provider.spec.ts
+++ b/spec/json-api-to-many-relationship-provider.spec.ts
@@ -1,76 +1,273 @@
+import { EntitySet } from '@dipscope/entity-store';
 import { generateRandomString, Message, SpecEntityStore, User } from './entity-store.spec';
+import { JsonApiToManyRelationship } from '../src';
 
-describe('Json api to many relationship provider', () =>
-{
-    it('should add new entities', async () =>
-    {
-        const specEntityStore = new SpecEntityStore();
-        const userSet = specEntityStore.userSet;
-        const messageSet = specEntityStore.messageSet;
-        const name = generateRandomString();
-        const user = new User(name, 1);
-        const addedUser = await userSet.add(user);
+async function addUser(userSet: EntitySet<User>, name?: string) {
+    name ??= generateRandomString();
+    const user = new User(name, 1);
+    const remoteUser = await userSet.add(user);
+    expect(remoteUser).toBe(user);
+    return remoteUser;
+}
+async function setupRelationshipTest() {
+    // Get Entity Store Objects
+    const specEntityStore = new SpecEntityStore();
+    const userSet = specEntityStore.userSet;
+    const messageSet = specEntityStore.messageSet;
+    const jsonApiEntityProvider = specEntityStore.jsonApiEntityProvider;
+    // Create a User
+    const user = await addUser(userSet);
+    // Create 3 initial Messages
+    const userMessages = jsonApiEntityProvider.createJsonApiToManyRelationship(userSet, user, u => u.messages);
+    const setupCount = 3;
+    const messages = [...Array(setupCount).keys()].map(() => createMessage(user));
+    const addedMessages = await messageSet.bulkAdd(messages);
+    expect(addedMessages.length).toBe(3);
+    expect(addedMessages.at(0)).toBe(messages[0]);
+    expect(addedMessages.at(1)).toBe(messages[1]);
+    expect(addedMessages.at(2)).toBe(messages[2]);
+    return { specEntityStore, userSet, messageSet, jsonApiEntityProvider, user, userMessages, addedMessages, setupCount }
+}
 
-        expect(addedUser).toBe(user);
+function createMessage(user: User, text?: string) {
+    text ??= generateRandomString();
+    return new Message(text, user);
+}
 
-        const messageX = new Message(name, addedUser);
-        const messageY = new Message(name, addedUser);
+async function getCurrentMessageCount(relationship: JsonApiToManyRelationship<User, Message>) {
+    const elements = await relationship.findAll();
+    return elements.length;
+}
 
-        const addedMessages = await messageSet.bulkAdd([messageX, messageY]);
+describe('Json api to many relationship provider', () => {
+    it('should fetch existing entities', async () => {
+        const { userSet, messageSet, userMessages, addedMessages, setupCount } = await setupRelationshipTest();
+        // This is a pre-check for validating that setup was ran correctly
+        const initialCount = await getCurrentMessageCount(userMessages);
+        expect(initialCount).toBe(setupCount);
 
-        expect(addedMessages.length).toBe(2);
-        expect(addedMessages.at(0)).toBe(messageX);
-        expect(addedMessages.at(1)).toBe(messageY);
+        // Create a new message, which isn't attached to user.
+        // To do this, we'll need to make a different user
+        const oddUser = await addUser(userSet);
+        const message = createMessage(oddUser);
+        await messageSet.add(message);
 
-        const jsonApiEntityProvider = specEntityStore.jsonApiEntityProvider;
-        const jsonApiToManyRelationship = jsonApiEntityProvider.createJsonApiToManyRelationship(userSet, user, u => u.messages);
-        const addedMessage = await jsonApiToManyRelationship.add(messageX);
+        // ! Function Under Test ! !
+        // Let's check that the message was linked correctly
+        const finalData = await userMessages.findAll();
+        expect(finalData.length).toBe(initialCount);
+        // Let's also check that our queried data is correct
+        for (let i = 0; i < setupCount; i++) {
+            expect(finalData.at(i)).toBe(addedMessages.at(i));
+        }
+    });
+    it('should add new entities', async () => {
+        const { userSet, messageSet, userMessages, setupCount } = await setupRelationshipTest();
+        // This is a pre-check for validating that setup was ran correctly
+        const initialCount = await getCurrentMessageCount(userMessages);
+        expect(initialCount).toBe(setupCount);
 
-        expect(addedMessage).toBe(messageX);
+        // Create a new message, which isn't attached to user.
+        // To do this, we'll need to make a different user
+        const oddUser = await addUser(userSet);
+        const message = createMessage(oddUser);
+        const addedMessage = await messageSet.add(message);
+
+        // This is a intermittent check for validating that message wasn't linked to user prematurely
+        const intermittentCount = await getCurrentMessageCount(userMessages);
+        expect(intermittentCount).toBe(initialCount);
+
+        // ! Function Under Test ! !
+        await userMessages.add(addedMessage);
+
+        // Let's check that the message was linked correctly
+        const finalData = await userMessages.findAll();
+        expect(finalData.length).toBe(initialCount + 1);
+
     });
 
-    it('should update existing entities', async () =>
-    {
-        // TODO: ...
+    it('should update existing entities', async () => {
+        const { userSet, messageSet, userMessages, setupCount } = await setupRelationshipTest();
+        // This is a pre-check for validating that setup was ran correctly
+        const initialCount = await getCurrentMessageCount(userMessages);
+        expect(initialCount).toBe(setupCount);
+
+        // Create a new message, which isn't attached to user.
+        // To do this, we'll need to make a different user
+        const oddUser = await addUser(userSet);
+        const message = createMessage(oddUser);
+        const addedMessage = await messageSet.add(message);
+
+        // This is a intermittent check for validating that message wasn't linked to user prematurely
+        const intermittentCount = await getCurrentMessageCount(userMessages);
+        expect(intermittentCount).toBe(initialCount);
+
+        // ! Function Under Test ! !
+        await userMessages.update(addedMessage);
+
+        // Let's check that the message was linked correctly
+        const finalData = await userMessages.findAll();
+        expect(finalData.length).toBe(1);
     });
 
-    it('should remove existing entities', async () =>
-    {
-        // TODO: ...
+    it('should remove existing entities', async () => {
+        const { userMessages, addedMessages, setupCount } = await setupRelationshipTest();
+        // This is a pre-check for validating that setup was ran correctly
+        const initialCount = await getCurrentMessageCount(userMessages);
+        expect(initialCount).toBe(setupCount);
+        const addedMessage = addedMessages.at(0);
+        expect(addedMessage).toBeDefined(); // ! Required for code assumptions
+
+        // ! Function Under Test ! !
+        if (addedMessage) {
+            await userMessages.remove(addedMessage);
+        }
+
+        // Let's check that the message was unlinked correctly
+        const finalData = await userMessages.findAll();
+        expect(finalData.length).toBe(initialCount - 1);
     });
 
-    it('should bulk add new entities', async () =>
-    {
-        // TODO: ...
+    it('should bulk add new entities', async () => {
+        const { userSet, messageSet, userMessages, setupCount } = await setupRelationshipTest();
+        // This is a pre-check for validating that setup was ran correctly
+        const initialCount = await getCurrentMessageCount(userMessages);
+        expect(initialCount).toBe(setupCount);
+
+        // Create a new message, which isn't attached to user.
+        // To do this, we'll need to make a different user
+        const oddUser = await addUser(userSet);
+        const messages = [...Array(setupCount).keys()].map(() => createMessage(oddUser));
+        const addedMessages = await messageSet.bulkAdd(messages);
+
+        // This is a intermittent check for validating that message wasn't linked to user prematurely
+        const intermittentCount = await getCurrentMessageCount(userMessages);
+        expect(intermittentCount).toBe(initialCount);
+
+        // ! Function Under Test ! !
+        await userMessages.bulkAdd(addedMessages);
+
+        // Let's check that the message was linked correctly
+        const finalData = await userMessages.findAll();
+        expect(finalData.length).toBe(initialCount + setupCount);
     });
 
-    it('should bulk update existing entities', async () =>
-    {
-        // TODO: ...
+    it('should bulk update existing entities', async () => {
+        const { userSet, messageSet, userMessages, setupCount } = await setupRelationshipTest();
+        // This is a pre-check for validating that setup was ran correctly
+        const initialCount = await getCurrentMessageCount(userMessages);
+        expect(initialCount).toBe(setupCount);
+
+        // Create a new message, which isn't attached to user.
+        // To do this, we'll need to make a different user
+        const oddUser = await addUser(userSet);
+        const messages = [...Array(setupCount - 1).keys()].map(() => createMessage(oddUser));
+        const addedMessages = await messageSet.bulkAdd(messages);
+
+        // This is a intermittent check for validating that message wasn't linked to user prematurely
+        const intermittentCount = await getCurrentMessageCount(userMessages);
+        expect(intermittentCount).toBe(initialCount);
+
+        // ! Function Under Test ! !
+        await userMessages.bulkUpdate(addedMessages);
+
+        // Let's check that the message was linked correctly
+        const finalData = await userMessages.findAll();
+        expect(finalData.length).toBe(setupCount - 1);
     });
 
-    it('should bulk remove existing entities', async () =>
-    {
-        // TODO: ...
+    it('should bulk remove existing entities', async () => {
+        const { userMessages, addedMessages, setupCount } = await setupRelationshipTest();
+        // This is a pre-check for validating that setup was ran correctly
+        const initialCount = await getCurrentMessageCount(userMessages);
+        expect(initialCount).toBe(setupCount);
+        const toRemoveMessages = [...Array(setupCount - 1).keys()].map(i => addedMessages.at(i)).filter(x => x ? true : false);
+        expect(toRemoveMessages.length).toBeGreaterThan(0); // ! Required for code assumptions
+
+        // ! Function Under Test ! !
+        await userMessages.bulkRemove(toRemoveMessages as Message[]);
+
+        // Let's check that the message was unlinked correctly
+        const finalData = await userMessages.findAll();
+        expect(finalData.length).toBe(1);
     });
 
-    it('should sort existing entities in ascending order', async () =>
-    {
-        // TODO: ...
+    it('should sort existing entities in ascending order', async () => {
+        const { user, messageSet, userMessages, setupCount } = await setupRelationshipTest();
+        // This is a pre-check for validating that setup was ran correctly
+        const initialCount = await getCurrentMessageCount(userMessages);
+        expect(initialCount).toBe(setupCount);
+
+        // Our random strings will start with an ISO string.
+        const messageA = createMessage(user, "00");
+        const addedMessageA = await messageSet.add(messageA);
+        const messageZ = createMessage(user, "ZULU");
+        const addedMessageZ = await messageSet.add(messageZ);
+
+        // ! Function Under Test ! !
+        // Let's check that the message was linked correctly
+        const finalData = await userMessages.sortByAsc(x => x.text).findAll();
+        expect(finalData.length).toBe(initialCount + 2);
+        expect(finalData.first()?.id).toBe(addedMessageA.id);
+        expect(finalData.last()?.id).toBe(addedMessageZ.id);
     });
 
-    it('should sort existing entities in descending order', async () =>
-    {
-        // TODO: ...
+    it('should sort existing entities in descending order', async () => {
+        const { user, messageSet, userMessages, setupCount } = await setupRelationshipTest();
+        // This is a pre-check for validating that setup was ran correctly
+        const initialCount = await getCurrentMessageCount(userMessages);
+        expect(initialCount).toBe(setupCount);
+
+        // Our random strings will start with an ISO string.
+        const messageA = createMessage(user, "00");
+        const addedMessageA = await messageSet.add(messageA);
+        const messageZ = createMessage(user, "ZULU");
+        const addedMessageZ = await messageSet.add(messageZ);
+
+        // ! Function Under Test ! !
+        // Let's check that the message was linked correctly
+        const finalData = await userMessages.sortByDesc(x => x.text).findAll();
+        expect(finalData.length).toBe(initialCount + 2);
+
+        expect(finalData.first()?.id).toBe(addedMessageZ.id);
+        expect(finalData.last()?.id).toBe(addedMessageA.id);
     });
 
-    it('should include relationships', async () =>
-    {
-        // TODO: ...
+    it('should include relationships', async () => {
+        const { user, userMessages, setupCount } = await setupRelationshipTest();
+        // This is a pre-check for validating that setup was ran correctly
+        const initialCount = await getCurrentMessageCount(userMessages);
+        expect(initialCount).toBe(setupCount);
+
+        // ! Function Under Test ! !
+        // Let's check that the message was linked correctly
+        const finalData = await userMessages.include(x => x.user).findAll();
+        expect(finalData.length).toBe(initialCount);
+
+        // Let's also check that our queried data is correct
+        for (let i = 0; i < setupCount; i++) {
+            expect(finalData.at(i)?.user).toBe(user);
+        }
     });
 
-    it('should paginate existing entities', async () =>
-    {
-        // TODO: ...
+    it('should paginate existing entities', async () => {
+        const { user, messageSet, userMessages, setupCount } = await setupRelationshipTest();
+        // This is a pre-check for validating that setup was ran correctly
+        const initialCount = await getCurrentMessageCount(userMessages);
+        expect(initialCount).toBe(setupCount);
+
+        // Create a lot of messages 
+        const messages = [...Array(20).keys()].map(() => createMessage(user));
+        await messageSet.bulkAdd(messages);
+
+        // ! Function Under Test ! !
+        // Let's check that the message was linked correctly
+        const page1Data = await userMessages.paginate(x => x.pageSize(1, 10)).findAll();
+        const page2Data = await userMessages.paginate(x => x.pageSize(2, 10)).findAll();
+        const page3Data = await userMessages.paginate(x => x.pageSize(3, 10)).findAll();
+
+        expect(page1Data.length).toBe(10);
+        expect(page2Data.length).toBe(10);
+        expect(page3Data.length).toBe(setupCount);
     });
 });

--- a/spec/json-api-to-one-relationship-provider.spec.ts
+++ b/spec/json-api-to-one-relationship-provider.spec.ts
@@ -43,7 +43,7 @@ describe('Json api to many relationship provider', () =>
 
         // ! Function Under Test ! !
         // Let's check that the message was linked correctly
-        const data = await userCompany.findOne();
+        const data = await userCompany.find();
         expect(data).toEqual(company);
     });
     
@@ -56,7 +56,7 @@ describe('Json api to many relationship provider', () =>
         await userCompany.update(company);
 
         // Let's check that the message was linked correctly
-        const finalData = await userCompany.findOne();
+        const finalData = await userCompany.find();
         expect(finalData?.id).toBe(company.id);
     });
 
@@ -72,39 +72,40 @@ describe('Json api to many relationship provider', () =>
         await userCompany.remove();
 
         // Let's check that the message was unlinked correctly
-        const finalData = await userCompany.findOne();
+        const finalData = await userCompany.find();
         expect(finalData).toBeNull();
     });
 
-    it('should include relationships', async () =>
-    {
-        const { userSet, company, userCompany, user } = await setupRelationshipTest();
-        expect(user.company).toBeUndefined();
-        // We have some continued setup, we need to assign a company to the user.
-        user.company = company;
-        const initialUser = await userSet.update(user);
-        expect(initialUser.company).toBeDefined();
+    // ! Include Clauses Not Yet Implemented !
+    // it('should include relationships', async () =>
+    // {
+    //     const { userSet, company, userCompany, user } = await setupRelationshipTest();
+    //     expect(user.company).toBeUndefined();
+    //     // We have some continued setup, we need to assign a company to the user.
+    //     user.company = company;
+    //     const initialUser = await userSet.update(user);
+    //     expect(initialUser.company).toBeDefined();
 
-        // ! Function Under Test ! !
-        // Let's check that the message was linked correctly
-        const data = await userCompany.include(x => x.users).findOne();
-        expect(data?.id).toEqual(company.id);
-        expect(data?.users.at(0)?.id).toEqual(user.id);
-    });
+    //     // ! Function Under Test ! !
+    //     // Let's check that the message was linked correctly
+    //     const data = await userCompany.include(x => x.users).findOne();
+    //     expect(data?.id).toEqual(company.id);
+    //     expect(data?.users.at(0)?.id).toEqual(user.id);
+    // });
 
-    it('should include a collection of relationships', async () =>
-    {
-        const { userSet, company, userCompany, user } = await setupRelationshipTest();
-        expect(user.company).toBeUndefined();
-        // We have some continued setup, we need to assign a company to the user.
-        user.company = company;
-        const initialUser = await userSet.update(user);
-        expect(initialUser.company).toBeDefined();
+    // it('should include a collection of relationships', async () =>
+    // {
+    //     const { userSet, company, userCompany, user } = await setupRelationshipTest();
+    //     expect(user.company).toBeUndefined();
+    //     // We have some continued setup, we need to assign a company to the user.
+    //     user.company = company;
+    //     const initialUser = await userSet.update(user);
+    //     expect(initialUser.company).toBeDefined();
 
-        // ! Function Under Test ! !
-        // Let's check that the message was linked correctly
-        const data = await userCompany.includeCollection(x => x.users).findOne();
-        expect(data?.id).toEqual(company.id);
-        expect(data?.users.at(0)?.id).toEqual(user.id);
-    });
+    //     // ! Function Under Test ! !
+    //     // Let's check that the message was linked correctly
+    //     const data = await userCompany.includeCollection(x => x.users).findOne();
+    //     expect(data?.id).toEqual(company.id);
+    //     expect(data?.users.at(0)?.id).toEqual(user.id);
+    // });
 });

--- a/spec/json-api-to-one-relationship-provider.spec.ts
+++ b/spec/json-api-to-one-relationship-provider.spec.ts
@@ -46,6 +46,7 @@ describe('Json api to many relationship provider', () =>
         const data = await userCompany.findOne();
         expect(data).toEqual(company);
     });
+    
     it('should update existing entities', async () =>
     {
         const { userCompany, company, user } = await setupRelationshipTest();
@@ -87,6 +88,22 @@ describe('Json api to many relationship provider', () =>
         // ! Function Under Test ! !
         // Let's check that the message was linked correctly
         const data = await userCompany.include(x => x.users).findOne();
+        expect(data?.id).toEqual(company.id);
+        expect(data?.users.at(0)?.id).toEqual(user.id);
+    });
+
+    it('should include a collection of relationships', async () =>
+    {
+        const { userSet, company, userCompany, user } = await setupRelationshipTest();
+        expect(user.company).toBeUndefined();
+        // We have some continued setup, we need to assign a company to the user.
+        user.company = company;
+        const initialUser = await userSet.update(user);
+        expect(initialUser.company).toBeDefined();
+
+        // ! Function Under Test ! !
+        // Let's check that the message was linked correctly
+        const data = await userCompany.includeCollection(x => x.users).findOne();
         expect(data?.id).toEqual(company.id);
         expect(data?.users.at(0)?.id).toEqual(user.id);
     });

--- a/spec/json-api-to-one-relationship-provider.spec.ts
+++ b/spec/json-api-to-one-relationship-provider.spec.ts
@@ -1,0 +1,93 @@
+import { EntitySet } from '@dipscope/entity-store';
+import { Company, generateRandomString, SpecEntityStore, User } from './entity-store.spec';
+
+async function addUser(userSet: EntitySet<User>, name?: string) 
+{
+    name ??= generateRandomString();
+    const user = new User(name, 1);
+    const remoteUser = await userSet.add(user);
+    expect(remoteUser).toBe(user);
+    return remoteUser;
+}
+async function setupRelationshipTest() 
+{
+    // Get Entity Store Objects
+    const specEntityStore = new SpecEntityStore();
+    const userSet = specEntityStore.userSet;
+    const companySet = specEntityStore.companySet;
+    const jsonApiEntityProvider = specEntityStore.jsonApiEntityProvider;
+    // Create a User and a Message
+    const user = await addUser(userSet);
+    const company = await companySet.add(createCompany());
+    // Create 3 initial Messages
+    const userCompany = jsonApiEntityProvider.createJsonApiToOneRelationship(userSet, user, u => u.company);
+    return { specEntityStore, company, userSet, companySet, jsonApiEntityProvider, user, userCompany }
+}
+
+function createCompany(text?: string) 
+{
+    text ??= generateRandomString();
+    return new Company(text);
+}
+
+describe('Json api to many relationship provider', () => 
+{
+    it('should fetch existing entity', async () =>
+    {
+        const { userSet, company, userCompany, user } = await setupRelationshipTest();
+        expect(user.company).toBeUndefined();
+        // We have some continued setup, we need to assign a company to the user.
+        user.company = company;
+        const initialUser = await userSet.update(user);
+        expect(initialUser.company).toBeDefined();
+
+        // ! Function Under Test ! !
+        // Let's check that the message was linked correctly
+        const data = await userCompany.findOne();
+        expect(data).toEqual(company);
+    });
+    it('should update existing entities', async () =>
+    {
+        const { userCompany, company, user } = await setupRelationshipTest();
+        expect(user.company).toBeUndefined();
+
+        // ! Function Under Test ! !
+        await userCompany.update(company);
+
+        // Let's check that the message was linked correctly
+        const finalData = await userCompany.findOne();
+        expect(finalData?.id).toBe(company.id);
+    });
+
+    it('should remove existing entities', async () =>
+    {
+        const { userCompany, user, company, userSet } = await setupRelationshipTest();
+        // We have some continued setup, we need to assign a company to the user.
+        user.company = company;
+        const initialUser = await userSet.update(user);
+        expect(initialUser.company).toBeDefined();
+
+        // ! Function Under Test ! !
+        await userCompany.remove();
+
+        // Let's check that the message was unlinked correctly
+        const finalData = await userCompany.findOne();
+        expect(finalData).toBeNull();
+    });
+
+    it('should include relationships', async () =>
+    {
+        const { userSet, company, userCompany, user } = await setupRelationshipTest();
+        expect(user.company).toBeUndefined();
+        // We have some continued setup, we need to assign a company to the user.
+        user.company = company;
+        const initialUser = await userSet.update(user);
+        expect(initialUser.company).toBeDefined();
+
+        // ! Function Under Test ! !
+        // Let's check that the message was linked correctly
+        const data = await userCompany.include(x => x.users).findOne();
+        expect(data?.id).toEqual(company.id);
+        expect(data?.users.at(0)?.id).toEqual(user.id);
+    });
+});

--- a/src/json-api-adapter.ts
+++ b/src/json-api-adapter.ts
@@ -202,11 +202,11 @@ export class JsonApiAdapter
      * 
      * @returns {LinkObject} Link object.
      */
-    public createRelationshipLinkObject<TEntity extends Entity, TRelationship extends Entity>(typeMetadata: TypeMetadata<TEntity>, entityOrIdentifier: TEntity | string, propertyMetadata: PropertyMetadata<TEntity, TRelationship>): LinkObject
+    public createRelationshipLinkObject<TEntity extends Entity, TRelationship extends Entity>(typeMetadata: TypeMetadata<TEntity>, entityOrIdentifier: TEntity | string, propertyMetadata: PropertyMetadata<TEntity, TRelationship>, selfLink: boolean = true): LinkObject
     {
         const resourceIdentifierLinkObject = this.createResourceIdentifierLinkObject(typeMetadata, entityOrIdentifier);
         const relationship = propertyMetadata.serializedPropertyName;
-        const linkObject = `${resourceIdentifierLinkObject}/relationships/${relationship}`;
+        const linkObject = `${resourceIdentifierLinkObject}/${selfLink ? 'relationships/' : ''}${relationship}`;
         
         return linkObject;
     }
@@ -298,7 +298,7 @@ export class JsonApiAdapter
      */
     public createRelationshipBrowseLinkObject<TEntity extends Entity, TRelationship extends Entity>(typeMetadata: TypeMetadata<TEntity>, entityOrIdentifier: TEntity | string, propertyMetadata: PropertyMetadata<TEntity, TRelationship>, browseCommand: BrowseCommand<TEntity, any>): LinkObject
     {
-        const relationshipLinkObject = this.createRelationshipLinkObject(typeMetadata, entityOrIdentifier, propertyMetadata);
+        const relationshipLinkObject = this.createRelationshipLinkObject(typeMetadata, entityOrIdentifier, propertyMetadata, false);
         const linkObject = this.createBrowseLinkObject(relationshipLinkObject, browseCommand);
 
         return linkObject;

--- a/src/json-api-adapter.ts
+++ b/src/json-api-adapter.ts
@@ -202,11 +202,11 @@ export class JsonApiAdapter
      * 
      * @returns {LinkObject} Link object.
      */
-    public createRelationshipLinkObject<TEntity extends Entity, TRelationship extends Entity>(typeMetadata: TypeMetadata<TEntity>, entityOrIdentifier: TEntity | string, propertyMetadata: PropertyMetadata<TEntity, TRelationship>, selfLink: boolean = true): LinkObject
+    public createRelationshipLinkObject<TEntity extends Entity, TRelationship extends Entity>(typeMetadata: TypeMetadata<TEntity>, entityOrIdentifier: TEntity | string, propertyMetadata: PropertyMetadata<TEntity, TRelationship>): LinkObject
     {
         const resourceIdentifierLinkObject = this.createResourceIdentifierLinkObject(typeMetadata, entityOrIdentifier);
         const relationship = propertyMetadata.serializedPropertyName;
-        const linkObject = `${resourceIdentifierLinkObject}/${selfLink ? 'relationships/' : ''}${relationship}`;
+        const linkObject = `${resourceIdentifierLinkObject}/relationships/${relationship}`;
         
         return linkObject;
     }
@@ -298,9 +298,10 @@ export class JsonApiAdapter
      */
     public createRelationshipBrowseLinkObject<TEntity extends Entity, TRelationship extends Entity>(typeMetadata: TypeMetadata<TEntity>, entityOrIdentifier: TEntity | string, propertyMetadata: PropertyMetadata<TEntity, TRelationship>, browseCommand: BrowseCommand<TEntity, any>): LinkObject
     {
-        const relationshipLinkObject = this.createRelationshipLinkObject(typeMetadata, entityOrIdentifier, propertyMetadata, false);
+        const resourceIdentifierLinkObject = this.createResourceIdentifierLinkObject(typeMetadata, entityOrIdentifier);
+        const relationship = propertyMetadata.serializedPropertyName;
+        const relationshipLinkObject = `${resourceIdentifierLinkObject}/${relationship}`;
         const linkObject = this.createBrowseLinkObject(relationshipLinkObject, browseCommand);
-
         return linkObject;
     }
 

--- a/src/json-api-to-one-relationship-provider.ts
+++ b/src/json-api-to-one-relationship-provider.ts
@@ -5,6 +5,7 @@ import { BulkUpdateCommand, QueryCommand, RemoveCommand, SaveCommand, UpdateComm
 import { PropertyMetadata, TypeMetadata } from '@dipscope/type-manager';
 import { JsonApiAdapter } from './json-api-adapter';
 import { JsonApiConnection } from './json-api-connection';
+import { JsonApiPaginatedEntityCollection } from './json-api-paginated-entity-collection';
 
 /**
  * Json api to one relationship provider.
@@ -186,7 +187,11 @@ export class JsonApiToOneRelationshipProvider implements EntityProvider
      */
     public async executeBulkQueryCommand<TEntity extends Entity>(bulkQueryCommand: BulkQueryCommand<TEntity>): Promise<PaginatedEntityCollection<TEntity>>
     {
-        throw new CommandNotSupportedError(bulkQueryCommand, this);
+        const typeMetadata = bulkQueryCommand.entityInfo.typeMetadata;
+        const linkObject = this.jsonApiAdapter.createRelationshipBrowseLinkObject(this.typeMetadata, this.entity, this.propertyMetadata, bulkQueryCommand);
+        const responseDocumentObject = await this.jsonApiConnection.get(linkObject);
+        const responseEntity = this.jsonApiAdapter.createDocumentObjectEntity(typeMetadata, responseDocumentObject);
+        return new JsonApiPaginatedEntityCollection(responseEntity ? [responseEntity] : [], typeMetadata, this.jsonApiAdapter);
     }
 
     /**

--- a/src/json-api-to-one-relationship-provider.ts
+++ b/src/json-api-to-one-relationship-provider.ts
@@ -5,7 +5,6 @@ import { BulkUpdateCommand, QueryCommand, RemoveCommand, SaveCommand, UpdateComm
 import { PropertyMetadata, TypeMetadata } from '@dipscope/type-manager';
 import { JsonApiAdapter } from './json-api-adapter';
 import { JsonApiConnection } from './json-api-connection';
-import { JsonApiPaginatedEntityCollection } from './json-api-paginated-entity-collection';
 
 /**
  * Json api to one relationship provider.
@@ -175,7 +174,11 @@ export class JsonApiToOneRelationshipProvider implements EntityProvider
      */
     public async executeQueryCommand<TEntity extends Entity>(queryCommand: QueryCommand<TEntity>): Promise<Nullable<TEntity>>
     {
-        throw new CommandNotSupportedError(queryCommand, this);
+        const typeMetadata = queryCommand.entityInfo.typeMetadata;
+        const linkObject = this.jsonApiAdapter.createRelationshipBrowseLinkObject(this.typeMetadata, this.entity, this.propertyMetadata, queryCommand);
+        const responseDocumentObject = await this.jsonApiConnection.get(linkObject);
+        const responseEntity = this.jsonApiAdapter.createDocumentObjectEntity(typeMetadata, responseDocumentObject);
+        return responseEntity;
     }
 
     /**
@@ -187,11 +190,7 @@ export class JsonApiToOneRelationshipProvider implements EntityProvider
      */
     public async executeBulkQueryCommand<TEntity extends Entity>(bulkQueryCommand: BulkQueryCommand<TEntity>): Promise<PaginatedEntityCollection<TEntity>>
     {
-        const typeMetadata = bulkQueryCommand.entityInfo.typeMetadata;
-        const linkObject = this.jsonApiAdapter.createRelationshipBrowseLinkObject(this.typeMetadata, this.entity, this.propertyMetadata, bulkQueryCommand);
-        const responseDocumentObject = await this.jsonApiConnection.get(linkObject);
-        const responseEntity = this.jsonApiAdapter.createDocumentObjectEntity(typeMetadata, responseDocumentObject);
-        return new JsonApiPaginatedEntityCollection(responseEntity ? [responseEntity] : [], typeMetadata, this.jsonApiAdapter);
+        throw new CommandNotSupportedError(bulkQueryCommand, this);
     }
 
     /**

--- a/src/json-api-to-one-relationship.ts
+++ b/src/json-api-to-one-relationship.ts
@@ -1,4 +1,4 @@
-import { Entity, EntitySet, IncludeBrowseCommandBuilder, IncludeClause, Nullable, PropertyInfo } from '@dipscope/entity-store';
+import { Entity, EntitySet, IncludeBrowseCommandBuilder, IncludeClause, IncludeCollectionClause, Nullable, PropertyInfo } from '@dipscope/entity-store';
 import { JsonApiEntityProvider } from './json-api-entity-provider';
 import { JsonApiToOneRelationshipProvider } from './json-api-to-one-relationship-provider';
 
@@ -88,6 +88,18 @@ export class JsonApiToOneRelationship<TEntity extends Entity, TRelationship exte
     public include<TProperty extends Entity>(includeClause: IncludeClause<TRelationship, TProperty>): IncludeBrowseCommandBuilder<TRelationship, TProperty> 
     {
         return this.relationshipSet.include(includeClause);
+    }
+
+    /**
+     * Includes entity collection for eager loading.
+     *
+     * @param {IncludeCollectionClause<TRelationship, TProperty>} includeCollectionClause Include collection clause.
+     *
+     * @returns {IncludeBrowseCommandBuilder<TRelationship, TProperty>} Include browse command builder.
+     */
+    public includeCollection<TProperty extends Entity>(includeCollectionClause: IncludeCollectionClause<TRelationship, TProperty>): IncludeBrowseCommandBuilder<TRelationship, TProperty> 
+    {
+        return this.relationshipSet.includeCollection(includeCollectionClause);
     }
     
     /**

--- a/src/json-api-to-one-relationship.ts
+++ b/src/json-api-to-one-relationship.ts
@@ -1,4 +1,4 @@
-import { Entity, EntitySet, PropertyInfo } from '@dipscope/entity-store';
+import { Entity, EntitySet, IncludeBrowseCommandBuilder, IncludeClause, Nullable, PropertyInfo } from '@dipscope/entity-store';
 import { JsonApiEntityProvider } from './json-api-entity-provider';
 import { JsonApiToOneRelationshipProvider } from './json-api-to-one-relationship-provider';
 
@@ -68,6 +68,28 @@ export class JsonApiToOneRelationship<TEntity extends Entity, TRelationship exte
         return;
     }
 
+    /**
+     * Finds one entity in a set.
+     *
+     * @returns {Promise<Nullable<TEntity>>} Entity or null.
+     */
+    public findOne(): Promise<Nullable<TRelationship>>
+    {
+        return this.relationshipSet.findOne();
+    }
+    
+    /**
+     * Includes entity for eager loading.
+     *
+     * @param {IncludeClause<TRelationship, TProperty>} includeClause Include clause.
+     *
+     * @returns {IncludeBrowseCommandBuilder<TRelationship, TProperty>} Include browse command builder.
+     */
+    public include<TProperty extends Entity>(includeClause: IncludeClause<TRelationship, TProperty>): IncludeBrowseCommandBuilder<TRelationship, TProperty> 
+    {
+        return this.relationshipSet.include(includeClause);
+    }
+    
     /**
      * Updates a relationship.
      *

--- a/src/json-api-to-one-relationship.ts
+++ b/src/json-api-to-one-relationship.ts
@@ -1,4 +1,4 @@
-import { Entity, EntitySet, IncludeBrowseCommandBuilder, IncludeClause, IncludeCollectionClause, Nullable, PropertyInfo } from '@dipscope/entity-store';
+import { Entity, EntitySet, Nullable, PropertyInfo } from '@dipscope/entity-store';
 import { JsonApiEntityProvider } from './json-api-entity-provider';
 import { JsonApiToOneRelationshipProvider } from './json-api-to-one-relationship-provider';
 
@@ -73,33 +73,9 @@ export class JsonApiToOneRelationship<TEntity extends Entity, TRelationship exte
      *
      * @returns {Promise<Nullable<TEntity>>} Entity or null.
      */
-    public findOne(): Promise<Nullable<TRelationship>>
+    public find(): Promise<Nullable<TRelationship>>
     {
-        return this.relationshipSet.findOne();
-    }
-    
-    /**
-     * Includes entity for eager loading.
-     *
-     * @param {IncludeClause<TRelationship, TProperty>} includeClause Include clause.
-     *
-     * @returns {IncludeBrowseCommandBuilder<TRelationship, TProperty>} Include browse command builder.
-     */
-    public include<TProperty extends Entity>(includeClause: IncludeClause<TRelationship, TProperty>): IncludeBrowseCommandBuilder<TRelationship, TProperty> 
-    {
-        return this.relationshipSet.include(includeClause);
-    }
-
-    /**
-     * Includes entity collection for eager loading.
-     *
-     * @param {IncludeCollectionClause<TRelationship, TProperty>} includeCollectionClause Include collection clause.
-     *
-     * @returns {IncludeBrowseCommandBuilder<TRelationship, TProperty>} Include browse command builder.
-     */
-    public includeCollection<TProperty extends Entity>(includeCollectionClause: IncludeCollectionClause<TRelationship, TProperty>): IncludeBrowseCommandBuilder<TRelationship, TProperty> 
-    {
-        return this.relationshipSet.includeCollection(includeCollectionClause);
+        return this.relationshipSet.find();
     }
     
     /**


### PR DESCRIPTION
# Description

Added Test Cases for the JsonAPI Entity Store ToMany Relationships Feature discussed in #7 
Seeing that 2 test conditions fail, more development may be needed on this feature.
* FindAll - does not retrieve Fields
* Include - does not attach related object

## Type of change

Test Coverage
# How Has This Been Tested?

Tests were validated using a Red-Green approach. (Fault Insertion)
Each test case was added using invalid expectations. Once the Failures were detected, the test was updated with the valid expecations.

For the 2 tests that are still failing, the lines in question were forced to pass instead of having a fault insertion, to ensure that the logic was operating correctly.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
