### PR TITLE
Add Morph Relationship Testing

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+// https://aka.ms/devcontainer.json
+// Not Fully Ready. Should see about merging the docker stages for development
+{
+    "name": "Existing Docker Compose (Extend) API",
+    "dockerComposeFile": [
+        "../backend/json-api-net/docker-compose.yml"
+    ],
+    "service": "jsonapinet",
+    "workspaceFolder": "/app"
+}

--- a/backend/json-api-net/AppDbContext.cs
+++ b/backend/json-api-net/AppDbContext.cs
@@ -61,6 +61,11 @@ namespace JsonApiNet
                 .WithMany()
                 .HasForeignKey(h => h.MotherId);
 
+            modelBuilder.Entity<Human>()
+                .HasOne(h => h.Spouse)
+                .WithMany()
+                .HasForeignKey(h => h.SpouseId);
+
             return;
         }
     }

--- a/backend/json-api-net/Human.cs
+++ b/backend/json-api-net/Human.cs
@@ -19,5 +19,9 @@ namespace JsonApiNet
 
         [HasMany]
         public ISet<Human> Children { get; set; } = new HashSet<Human>();
+
+        [HasOne]
+        public Human? Spouse { get; set; }
+        public int? SpouseId { get; set; }
     }
 }

--- a/spec/entity-store.spec.ts
+++ b/spec/entity-store.spec.ts
@@ -145,6 +145,7 @@ export class Human extends JsonApiEntity
     @Property(String) public name;
     @Property(() => Man) public father?: Man;
     @Property(() => Woman) public mother?: Woman;
+    @Property(() => Human) public spouse?: Human;
     @Property(EntityCollection, [() => Human]) public children: EntityCollection<Human>;
 
     public constructor(name: string)

--- a/spec/json-api-morph-many-relationship-provider.ignore
+++ b/spec/json-api-morph-many-relationship-provider.ignore
@@ -1,0 +1,408 @@
+import { EntitySet } from '@dipscope/entity-store';
+import { JsonApiToManyRelationship } from '../src';
+import { generateRandomString, SpecEntityStore, Human, Woman, Man } from './entity-store.spec';
+
+function generateRandomBool(): boolean
+{
+    return Math.round(Math.random()) === 1;
+}
+async function addHuman(humanSet: EntitySet<Human>, name?: string, sex?: 'Man'|'Woman') 
+{
+    sex ??= generateRandomBool() ? 'Man' : 'Woman';
+    name ??= generateRandomString();
+
+    const human = sex === 'Man' ? new Man(name, generateRandomBool()) : new Woman(name, generateRandomString());
+    const remoteHuman = await humanSet.add(human);
+
+    expect(remoteHuman).toBe(human);
+
+    return remoteHuman;
+}
+
+async function setupRelationshipTest() 
+{
+    // Get Entity Store Objects.
+    const specEntityStore = new SpecEntityStore();
+    const humanSet = specEntityStore.humanSet;
+    const jsonApiEntityProvider = specEntityStore.jsonApiEntityProvider;
+
+    // Create a Human.
+    const mother = await addHuman(humanSet, undefined, 'Woman') as Woman;
+    const father = await addHuman(humanSet, undefined, 'Man') as Man;
+
+    // Create 3 initial Children.
+    const motherChildren = jsonApiEntityProvider.createJsonApiToManyRelationship(humanSet, mother, u => u.children);
+    const setupCount = 3;
+    const children = [...Array(setupCount).keys()].map(() => createChild(mother, father));
+    const addedChildrens = await humanSet.bulkAdd(children);
+
+    expect(addedChildrens.length).toBe(setupCount);
+
+    for(let i = 0; i < setupCount; i ++)
+    {
+        expect(addedChildrens.at(i)).toBe(children[i])
+    }
+
+    return { specEntityStore, humanSet, jsonApiEntityProvider, mother, father, motherChildren, addedChildrens, setupCount };
+}
+
+function createChild(mother?: Woman, father?: Man, name?: string, sex?: 'Man'|'Woman') 
+{
+    sex ??= generateRandomBool() ? 'Man' : 'Woman';
+    name ??= generateRandomString();
+
+    const child = sex === 'Man' ?new Man(name, generateRandomBool()) : new Woman(name, generateRandomString());
+    child.mother = mother;
+    child.father = father;
+    return child;
+}
+
+async function getCurrentChildrenCount(relationship: JsonApiToManyRelationship<Human, Human>) 
+{
+    const elements = await relationship.findAll();
+
+    return elements.length;
+}
+
+describe('Json api to many relationship provider', () => 
+{
+    it('should fetch existing entities', async () =>
+    {
+        const { humanSet, motherChildren, addedChildrens: addedChildren, mother, father, setupCount } = await setupRelationshipTest();
+
+        // This is a pre-check for validating that setup was ran correctly.
+        const initialCount = await getCurrentChildrenCount(motherChildren);
+
+        expect(initialCount).toBe(setupCount);
+
+        // Create a new child, which isn't attached to the mother.
+        // To do this, we'll need to make a different mother.
+        const newMother = await addHuman(humanSet, undefined, 'Woman') as Woman;
+        const child = createChild(newMother, father);
+
+        await humanSet.add(child);
+
+        // ! Function Under Test !
+        // Let's check that the children was linked correctly.
+        const finalData = await motherChildren.findAll();
+
+        expect(finalData.length).toBe(initialCount);
+
+        // Let's also check that our queried data is correct.
+        // Sort Data.
+        const sortedFinalData = finalData.sort((a, b) => (a.name > b.name ? -1 : 1));
+        const sortedChildren = addedChildren.sort((a, b) => (a.name > b.name ? -1 : 1));
+
+        for (let i = 0; i < setupCount; i++)
+        {
+            const actual = sortedFinalData.at(i);
+            const expected = sortedChildren.at(i);
+
+            if (actual && expected)
+            {
+                actual.mother = mother;
+                expected.father = father;
+            }
+
+            expect(actual).toEqual(expected);
+        }
+    });
+
+    it('should add new entities', async () =>
+    {
+        const { humanSet, motherChildren, father, setupCount } = await setupRelationshipTest();
+
+        // This is a pre-check for validating that setup was ran correctly.
+        const initialCount = await getCurrentChildrenCount(motherChildren);
+
+        expect(initialCount).toBe(setupCount);
+
+        // Create a new children, which isn't attached to human.
+        // To do this, we'll need to make a different human.
+        const otherMother = await addHuman(humanSet, undefined, 'Woman') as Woman;
+        const child = createChild(otherMother, father);
+        const addedChildren = await humanSet.add(child);
+
+        // This is a intermittent check for validating that children wasn't linked to human prematurely.
+        const intermittentCount = await getCurrentChildrenCount(motherChildren);
+
+        expect(intermittentCount).toBe(initialCount);
+
+        // ! Function Under Test !
+        await motherChildren.add(addedChildren);
+
+        // Let's check that the children was linked correctly.
+        const finalData = await motherChildren.findAll();
+
+        expect(finalData.length).toBe(initialCount + 1);
+    });
+
+    it('should update existing entities', async () =>
+    {
+        const { humanSet, motherChildren, father, setupCount } = await setupRelationshipTest();
+
+        // This is a pre-check for validating that setup was ran correctly.
+        const initialCount = await getCurrentChildrenCount(motherChildren);
+
+        expect(initialCount).toBe(setupCount);
+
+        // Create a new children, which isn't attached to human.
+        // To do this, we'll need to make a different human.
+        const otherMother = await addHuman(humanSet, undefined, 'Woman') as Woman;
+        const children = createChild(otherMother, father);
+        const addedChildren = await humanSet.add(children);
+
+        // This is a intermittent check for validating that children wasn't linked to human prematurely.
+        const intermittentCount = await getCurrentChildrenCount(motherChildren);
+
+        expect(intermittentCount).toBe(initialCount);
+
+        // ! Function Under Test !
+        await motherChildren.update(addedChildren);
+
+        // Let's check that the children was linked correctly.
+        const finalData = await motherChildren.findAll();
+
+        expect(finalData.length).toBe(1);
+    });
+
+    it('should remove existing entities', async () =>
+    {
+        const { motherChildren, addedChildrens, setupCount } = await setupRelationshipTest();
+
+        // This is a pre-check for validating that setup was ran correctly
+        const initialCount = await getCurrentChildrenCount(motherChildren);
+
+        expect(initialCount).toBe(setupCount);
+
+        const addedChildren = addedChildrens.at(0);
+
+        expect(addedChildren).toBeDefined(); // ! Required for code assumptions.
+
+        // ! Function Under Test !
+        if (addedChildren) 
+        {
+            await motherChildren.remove(addedChildren);
+        }
+
+        // Let's check that the children was unlinked correctly.
+        const finalData = await motherChildren.findAll();
+
+        expect(finalData.length).toBe(initialCount - 1);
+    });
+
+    it('should bulk add new entities', async () =>
+    {
+        const { humanSet, motherChildren, father, setupCount } = await setupRelationshipTest();
+
+        // This is a pre-check for validating that setup was ran correctly.
+        const initialCount = await getCurrentChildrenCount(motherChildren);
+
+        expect(initialCount).toBe(setupCount);
+
+        // Create a new children, which isn't attached to human.
+        // To do this, we'll need to make a different human.
+        const otherMother = await addHuman(humanSet, undefined, 'Woman') as Woman;
+        const childrens = [...Array(setupCount).keys()].map(() => createChild(otherMother, father));
+        const addedChildrens = await humanSet.bulkAdd(childrens);
+
+        // This is a intermittent check for validating that children wasn't linked to human prematurely.
+        const intermittentCount = await getCurrentChildrenCount(motherChildren);
+
+        expect(intermittentCount).toBe(initialCount);
+
+        // ! Function Under Test !
+        await motherChildren.bulkAdd(addedChildrens);
+
+        // Let's check that the children was linked correctly.
+        const finalData = await motherChildren.findAll();
+
+        expect(finalData.length).toBe(initialCount + setupCount);
+    });
+
+    it('should bulk update existing entities', async () =>
+    {
+        const { humanSet, motherChildren, father, setupCount } = await setupRelationshipTest();
+
+        // This is a pre-check for validating that setup was ran correctly.
+        const initialCount = await getCurrentChildrenCount(motherChildren);
+
+        expect(initialCount).toBe(setupCount);
+
+        // Create a new children, which isn't attached to human.
+        // To do this, we'll need to make a different human.
+        const otherMother = await addHuman(humanSet, undefined, 'Woman') as Woman;
+        const childrens = [...Array(setupCount - 1).keys()].map(() => createChild(otherMother, father));
+        const addedChildrens = await humanSet.bulkAdd(childrens);
+
+        // This is a intermittent check for validating that children wasn't linked to human prematurely.
+        const intermittentCount = await getCurrentChildrenCount(motherChildren);
+
+        expect(intermittentCount).toBe(initialCount);
+
+        // ! Function Under Test !
+        await motherChildren.bulkUpdate(addedChildrens);
+
+        // Let's check that the children was linked correctly.
+        const finalData = await motherChildren.findAll();
+
+        expect(finalData.length).toBe(setupCount - 1);
+    });
+
+    it('should bulk remove existing entities', async () =>
+    {
+        const { motherChildren, addedChildrens, setupCount } = await setupRelationshipTest();
+
+        // This is a pre-check for validating that setup was ran correctly.
+        const initialCount = await getCurrentChildrenCount(motherChildren);
+
+        expect(initialCount).toBe(setupCount);
+
+        const toRemoveChildrens = [...Array(setupCount - 1).keys()].map(i => addedChildrens.at(i)).filter(x => x ? true : false);
+
+        expect(toRemoveChildrens.length).toBeGreaterThan(0); // ! Required for code assumptions.
+
+        // ! Function Under Test !
+        await motherChildren.bulkRemove(toRemoveChildrens as Human[]);
+
+        // Let's check that the children was unlinked correctly.
+        const finalData = await motherChildren.findAll();
+
+        expect(finalData.length).toBe(1);
+    });
+
+    it('should sort existing entities in ascending order', async () =>
+    {
+        const { mother, humanSet, motherChildren, setupCount } = await setupRelationshipTest();
+
+        // This is a pre-check for validating that setup was ran correctly.
+        const initialCount = await getCurrentChildrenCount(motherChildren);
+
+        expect(initialCount).toBe(setupCount);
+
+        // Our random strings will start with an ISO string.
+        const childrenA = createChild(mother, undefined, '00');
+        const addedChildrenA = await humanSet.add(childrenA);
+        const childrenZ = createChild(mother, undefined, 'ZULU');
+        const addedChildrenZ = await humanSet.add(childrenZ);
+
+        // ! Function Under Test !
+        // Let's check that the children was linked correctly.
+        const finalData = await motherChildren.sortByAsc(x => x.name).findAll();
+
+        expect(finalData.length).toBe(initialCount + 2);
+        expect(finalData.first()?.id).toBe(addedChildrenA.id);
+        expect(finalData.last()?.id).toBe(addedChildrenZ.id);
+    });
+
+    it('should sort existing entities in descending order', async () =>
+    {
+        const { mother, humanSet, motherChildren, setupCount } = await setupRelationshipTest();
+
+        // This is a pre-check for validating that setup was ran correctly.
+        const initialCount = await getCurrentChildrenCount(motherChildren);
+
+        expect(initialCount).toBe(setupCount);
+
+        // Our random strings will start with an ISO string.
+        const childrenA = createChild(mother, undefined, '00');
+        const addedChildrenA = await humanSet.add(childrenA);
+        const childrenZ = createChild(mother, undefined, 'ZULU');
+        const addedChildrenZ = await humanSet.add(childrenZ);
+
+        // ! Function Under Test !
+        // Let's check that the children was linked correctly.
+        const finalData = await motherChildren.sortByDesc(x => x.name).findAll();
+
+        expect(finalData.length).toBe(initialCount + 2);
+        expect(finalData.first()?.id).toBe(addedChildrenZ.id);
+        expect(finalData.last()?.id).toBe(addedChildrenA.id);
+    });
+
+    it('should include relationships', async () =>
+    {
+        const { mother, motherChildren, setupCount } = await setupRelationshipTest();
+
+        // This is a pre-check for validating that setup was ran correctly.
+        const initialCount = await getCurrentChildrenCount(motherChildren);
+
+        expect(initialCount).toBe(setupCount);
+
+        // ! Function Under Test !
+        // Let's check that the children was linked correctly.
+        const finalData = await motherChildren.include(x => x.children).findAll();
+
+        expect(finalData.length).toBe(initialCount);
+
+        // Let's also check that our queried data is correct.
+        for (let i = 0; i < setupCount; i++)
+        {
+            expect(finalData.at(i)?.mother).toEqual(mother);
+        }
+    });
+    
+    it('should include a collection of relationships', async () =>
+    {
+        const { mother, father, motherChildren, humanSet, setupCount, addedChildrens } = await setupRelationshipTest();
+
+        // This is a pre-check for validating that setup was ran correctly.
+        const initialCount = await getCurrentChildrenCount(motherChildren);
+
+        expect(initialCount).toBe(setupCount);
+
+        const children = addedChildrens.at(0);
+
+        expect(children).toBeDefined();
+
+        if(!children?.id) 
+        { 
+            return;
+        }
+
+        const reply = createChild(mother, father);
+        const addedReply = await humanSet.add(reply);
+
+        expect(addedReply.mother).toBe(mother);
+
+        // ! Function Under Test !
+        // Let's check that the children was linked correctly.
+        const finalData = await motherChildren
+            .filter((m, eb) => eb.eq(m.id, children.id ?? 0))
+            .include(x => x.mother)   
+            .thenIncludeCollection(x => x.children)      
+            .thenInclude(x => x.father)
+            .findOne();
+        
+        expect(finalData?.id).toBe(children.id);
+        expect(finalData?.mother?.children.length).toBe(1);
+        expect(finalData?.mother?.children.at(0)?.id).toBe(addedReply.id);
+    });
+
+    it('should paginate existing entities', async () => 
+    {
+        const { mother, father, humanSet, motherChildren, setupCount } = await setupRelationshipTest();
+        const paginationSetSize = 20;
+        const paginationSampleSize = 10;
+        const secondToLastPage = paginationSetSize/paginationSampleSize;
+        const lastPage = secondToLastPage + 1;
+
+        // This is a pre-check for validating that setup was ran correctly.
+        const initialCount = await getCurrentChildrenCount(motherChildren);
+
+        expect(initialCount).toBe(setupCount);
+
+        // Create a lot of childrens.
+        const childrens = [...Array(paginationSetSize).keys()].map(() => createChild(mother, father));
+        await humanSet.bulkAdd(childrens);
+
+        // ! Function Under Test !
+        // Let's check that the children was linked correctly.
+        const firstPageData = await motherChildren.paginate(x => x.pageSize(1, paginationSampleSize)).findAll();
+        const pageNeg1Data = await motherChildren.paginate(x => x.pageSize(secondToLastPage, paginationSampleSize)).findAll();
+        const lastPageData = await motherChildren.paginate(x => x.pageSize(lastPage, paginationSampleSize)).findAll();
+
+        expect(firstPageData.length).toBe(paginationSampleSize);
+        expect(pageNeg1Data.length).toBe(paginationSampleSize);
+        expect(lastPageData.length).toBe(setupCount);
+    });
+});

--- a/spec/json-api-morph-one-relationship-provider.spec.ts
+++ b/spec/json-api-morph-one-relationship-provider.spec.ts
@@ -1,0 +1,136 @@
+import { EntitySet } from '@dipscope/entity-store';
+import { generateRandomString, SpecEntityStore, Human, Man, Woman } from './entity-store.spec';
+
+function generateRandomBool(): boolean
+{
+    return Math.round(Math.random()) === 1;
+}
+async function addHuman(humanSet: EntitySet<Human>, name?: string, sex?: 'Man'|'Woman') 
+{
+    sex ??= generateRandomBool() ? 'Man' : 'Woman';
+    name ??= generateRandomString();
+
+    const human = sex === 'Man' ? new Man(name, generateRandomBool()) : new Woman(name, generateRandomString());
+    const remoteHuman = await humanSet.add(human);
+
+    expect(remoteHuman).toBe(human);
+
+    return remoteHuman;
+}
+
+async function setupRelationshipTest() 
+{
+    // Get Entity Store Objects.
+    const specEntityStore = new SpecEntityStore();
+    const humanSet = specEntityStore.humanSet;
+    const jsonApiEntityProvider = specEntityStore.jsonApiEntityProvider;
+
+    // Create two humans.
+    const human = await addHuman(humanSet);
+    const spouse = await addHuman(humanSet);
+
+    // Create 3 initial Messages.
+    const humanSpouse = jsonApiEntityProvider.createJsonApiToOneRelationship(humanSet, human, u => u.spouse);
+
+    return { specEntityStore, spouse, humanSet, jsonApiEntityProvider, human, humanSpouse };
+}
+
+describe('Json api morph to many relationship provider', () => 
+{
+    it('should fetch existing entity', async () =>
+    {
+        const { humanSet, spouse, humanSpouse, human } = await setupRelationshipTest();
+
+        expect(human.spouse).toBeUndefined();
+
+        // We have some continued setup, we need to assign a company to the human.
+        human.spouse = spouse;
+
+        const initialHuman = await humanSet.update(human);
+
+        expect(initialHuman.spouse).toBeDefined();
+
+        // ! Function Under Test !
+        // Let's check that the message was linked correctly.
+        const data = await humanSpouse.find();
+
+        expect(data).toEqual(spouse);
+    });
+    
+    it('should update existing entities', async () =>
+    {
+        const { humanSpouse, spouse, human } = await setupRelationshipTest();
+        expect(human.spouse).toBeUndefined();
+
+        // ! Function Under Test !
+        await humanSpouse.update(spouse);
+
+        // Let's check that the message was linked correctly.
+        const finalData = await humanSpouse.find();
+
+        expect(finalData?.id).toBe(spouse.id);
+    });
+
+    it('should remove existing entities', async () =>
+    {
+        const { humanSpouse, human, spouse, humanSet } = await setupRelationshipTest();
+
+        // We have some continued setup, we need to assign a spouse to the human.
+        human.spouse = spouse;
+
+        const initialHuman = await humanSet.update(human);
+
+        expect(initialHuman.spouse).toBeDefined();
+
+        // ! Function Under Test !
+        await humanSpouse.remove();
+
+        // Let's check that the message was unlinked correctly.
+        const finalData = await humanSpouse.find();
+
+        expect(finalData).toBeNull();
+    });
+
+    // ! Include Clauses Not Yet Implemented !
+    // it('should include relationships', async () =>
+    // {
+    //     const { humanSet, spouse, humanSpouse, human } = await setupRelationshipTest();
+    // 
+    //     expect(human.spouse).toBeUndefined();
+    //
+    //     // We have some continued setup, we need to assign a spouse to the human.
+    //     human.spouse = spouse;
+    //
+    //     const initialHuman = await humanSet.update(human);
+    //
+    //     expect(initialHuman.spouse).toBeDefined();
+    //
+    //     // ! Function Under Test !
+    //     // Let's check that the message was linked correctly.
+    //     const data = await humanSpouse.include(x => x.humans).findOne();
+    //
+    //     expect(data?.id).toEqual(spouse.id);
+    //     expect(data?.humans.at(0)?.id).toEqual(human.id);
+    // });
+
+    // it('should include a collection of relationships', async () =>
+    // {
+    //     const { humanSet, spouse, humanSpouse, human } = await setupRelationshipTest();
+    //
+    //     expect(human.spouse).toBeUndefined();
+    //
+    //     // We have some continued setup, we need to assign a spouse to the human.
+    //     human.spouse = spouse;
+    //
+    //     const initialHuman = await humanSet.update(human);
+    //
+    //     expect(initialHuman.spouse).toBeDefined();
+    //
+    //     // ! Function Under Test !
+    //     // Let's check that the message was linked correctly.
+    //     const data = await humanSpouse.includeCollection(x => x.humans).findOne();
+    //
+    //     expect(data?.id).toEqual(spouse.id);
+    //     expect(data?.humans.at(0)?.id).toEqual(human.id);
+    // });
+});

--- a/spec/json-api-to-many-relationship-provider.spec.ts
+++ b/spec/json-api-to-many-relationship-provider.spec.ts
@@ -55,7 +55,7 @@ async function getCurrentMessageCount(relationship: JsonApiToManyRelationship<Us
     return elements.length;
 }
 
-describe('Json api to many relationship provider', () => 
+describe('Json api morph to many relationship provider', () => 
 {
     it('should fetch existing entities', async () =>
     {
@@ -357,9 +357,10 @@ describe('Json api to many relationship provider', () =>
 
         // ! Function Under Test !
         // Let's check that the message was linked correctly.
-        const finalData = await userMessages.filter((m, eb) => eb.eq(m.id, message.id))
+        const finalData = await userMessages
+            .filter((m, eb) => eb.eq(m.id, message.id ?? 0))
             .includeCollection(x => x.messages)
-            .thenInclude(x => x.parent)
+            .thenInclude(x => x.parent)         
             .includeCollection(x => x.messages)
             .thenInclude(x => x.user)
             .findOne();


### PR DESCRIPTION
# Description

Added code to support testing the API communication for polymorphic relationships. This includes adding `Spouse` to Human for a polymorphic-to-one relationship.

At the moment of PR creation, the backend does not return any children under the `/mans/:id/children` or `/womans/:id/children` endpoints. This prevents morph-to-many testing from being functional.
