### PR TITLE
Added configuration to allow cross origin cookies

### DIFF
--- a/src/json-api-connection.ts
+++ b/src/json-api-connection.ts
@@ -43,6 +43,11 @@ export class JsonApiConnection
      * @type {Headers}
      */
     public readonly headers: Headers;
+
+    /**
+     * The browser cookie access policy
+     */
+    public readonly credentials: RequestCredentials;
     
     /**
      * Constructor.
@@ -54,13 +59,15 @@ export class JsonApiConnection
     public constructor(
         baseUrl: string, 
         jsonApiRequestInterceptor: JsonApiRequestInterceptor, 
-        jsonApiResponseInterceptor: JsonApiResponseInterceptor
+        jsonApiResponseInterceptor: JsonApiResponseInterceptor,
+        credentials: RequestCredentials = 'same-origin',
     )
     {
         this.baseUrl = baseUrl.replace(new RegExp('\\/+$', 'g'), '');
         this.jsonApiRequestInterceptor = jsonApiRequestInterceptor;
         this.jsonApiResponseInterceptor = jsonApiResponseInterceptor;
         this.headers = this.buildHeaders();
+        this.credentials = credentials;
 
         return;
     }
@@ -91,7 +98,7 @@ export class JsonApiConnection
     {
         const href = this.extractHref(linkObject);
         const headers = new Headers(this.headers);
-        const request = new Request(href, { headers: headers, credentials: 'same-origin', method: 'GET' });
+        const request = new Request(href, { headers: headers, credentials: this.credentials, method: 'GET' });
         const interceptedRequest = this.jsonApiRequestInterceptor(request);
         const response = await fetch(interceptedRequest);
         const interceptedResponse = this.jsonApiResponseInterceptor(response);
@@ -121,7 +128,7 @@ export class JsonApiConnection
         const href = this.extractHref(linkObject);
         const body = JSON.stringify(documentObject);
         const headers = new Headers(this.headers);
-        const request = new Request(href, { headers: headers, credentials: 'same-origin', method: 'POST', body: body });
+        const request = new Request(href, { headers: headers, credentials: this.credentials, method: 'POST', body: body });
         const interceptedRequest = this.jsonApiRequestInterceptor(request);
         const response = await fetch(interceptedRequest);
         const interceptedResponse = this.jsonApiResponseInterceptor(response);
@@ -158,7 +165,7 @@ export class JsonApiConnection
         const href = this.extractHref(linkObject);
         const body = JSON.stringify(documentObject);
         const headers = new Headers(this.headers);
-        const request = new Request(href, { headers: headers, credentials: 'same-origin', method: 'PATCH', body: body });
+        const request = new Request(href, { headers: headers, credentials: this.credentials, method: 'PATCH', body: body });
         const interceptedRequest = this.jsonApiRequestInterceptor(request);
         const response = await fetch(interceptedRequest);
         const interceptedResponse = this.jsonApiResponseInterceptor(response);
@@ -195,7 +202,7 @@ export class JsonApiConnection
         const href = this.extractHref(linkObject);
         const body = isEmpty(documentObject) ? undefined : JSON.stringify(documentObject);
         const headers = new Headers(this.headers);
-        const request = new Request(href, { headers: headers, credentials: 'same-origin', method: 'DELETE', body: body });
+        const request = new Request(href, { headers: headers, credentials: this.credentials, method: 'DELETE', body: body });
         const interceptedRequest = this.jsonApiRequestInterceptor(request);
         const response = await fetch(interceptedRequest);
         const interceptedResponse = this.jsonApiResponseInterceptor(response);

--- a/src/json-api-entity-provider-options.ts
+++ b/src/json-api-entity-provider-options.ts
@@ -61,4 +61,9 @@ export interface JsonApiEntityProviderOptions
      * @type {boolean}
      */
     allowToManyRelationshipReplacement?: boolean;
+    
+    /**
+     * The browser cookie access policy
+     */
+    credentials?: RequestCredentials;
 }

--- a/src/json-api-entity-provider.ts
+++ b/src/json-api-entity-provider.ts
@@ -53,8 +53,9 @@ export class JsonApiEntityProvider implements EntityProvider
         const jsonApiPaginateExpressionVisitor = jsonApiEntityProviderOptions.jsonApiPaginateExpressionVisitor ?? new JsonApiPaginateExpressionVisitor();
         const jsonApiSortExpressionVisitor = new JsonApiSortExpressionVisitor();
         const jsonApiIncludeExpressionVisitor = new JsonApiIncludeExpressionVisitor();
+        const credentials = jsonApiEntityProviderOptions.credentials ?? 'same-origin';
         
-        this.jsonApiConnection = new JsonApiConnection(jsonApiEntityProviderOptions.baseUrl, jsonApiRequestInterceptor, jsonApiResponseInterceptor);
+        this.jsonApiConnection = new JsonApiConnection(jsonApiEntityProviderOptions.baseUrl, jsonApiRequestInterceptor, jsonApiResponseInterceptor, credentials);
         this.jsonApiAdapter = new JsonApiAdapter(this.jsonApiConnection, jsonApiMetadataExtractor, jsonApiFilterExpressionVisitor, jsonApiPaginateExpressionVisitor, jsonApiSortExpressionVisitor, jsonApiIncludeExpressionVisitor, allowToManyRelationshipReplacement);
 
         return;


### PR DESCRIPTION
# Description

Adds a configuration setting to enable cross origin cookies (`credentials` set to `include` on Fetch API calls)
This is needed for cross-origin API calls with cookie-based authentication. I didn't add testing, as it'd require configuring CORS on the backend. That being said, I have sideloaded the code into my application and can now execute cross-origin requests successfully. (It's a low-risk feature, as it is a configuration setting passed into the connection class, defaults to the 'same-origin' that was previously hardcoded)


Fixes #17

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

None, only validate by sideloading into an application.
(Cookies are a great weakness of mine, I don't know how to test them)

## Checklist before requesting a review

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
