### PR TITLE
Add JsonApiFetchInterceptor

### DIFF
--- a/spec/json-api-entity-provider.spec.ts
+++ b/spec/json-api-entity-provider.spec.ts
@@ -2,6 +2,14 @@ import { generateRandomString, Man, Message, SpecEntityStore, User, UserStatus, 
 
 describe('Json api entity provider', () =>
 {
+    it('should allow for fetch interceptors', async () =>
+    {
+        const specEntityStore = new SpecEntityStore('error');
+        const userSet = specEntityStore.userSet;
+        const name = generateRandomString();
+        const user = new User(name, 1);
+        await expectAsync(userSet.add(user)).toBeRejectedWithError('Fetch Request Intercepted');
+    });
     it('should add new entities', async () =>
     {
         const specEntityStore = new SpecEntityStore();

--- a/src/json-api-connection.ts
+++ b/src/json-api-connection.ts
@@ -133,7 +133,7 @@ export class JsonApiConnection
         const headers = new Headers(this.headers);
         const request = new Request(href, { headers: headers, credentials: 'same-origin', method: 'POST', body: body });
         const interceptedRequest = this.jsonApiRequestInterceptor(request);
-        const response = await fetch(interceptedRequest);
+        const response = await this.jsonApiFetchInterceptor(interceptedRequest);
         const interceptedResponse = this.jsonApiResponseInterceptor(response);
         const responseDocumentObject = await this.extractDocumentObject(interceptedResponse);
 
@@ -170,7 +170,7 @@ export class JsonApiConnection
         const headers = new Headers(this.headers);
         const request = new Request(href, { headers: headers, credentials: 'same-origin', method: 'PATCH', body: body });
         const interceptedRequest = this.jsonApiRequestInterceptor(request);
-        const response = await fetch(interceptedRequest);
+        const response = await this.jsonApiFetchInterceptor(interceptedRequest);
         const interceptedResponse = this.jsonApiResponseInterceptor(response);
         const responseDocumentObject = await this.extractDocumentObject(interceptedResponse);
 
@@ -207,7 +207,7 @@ export class JsonApiConnection
         const headers = new Headers(this.headers);
         const request = new Request(href, { headers: headers, credentials: 'same-origin', method: 'DELETE', body: body });
         const interceptedRequest = this.jsonApiRequestInterceptor(request);
-        const response = await fetch(interceptedRequest);
+        const response = await this.jsonApiFetchInterceptor(interceptedRequest);
         const interceptedResponse = this.jsonApiResponseInterceptor(response);
         const responseDocumentObject = await this.extractDocumentObject(interceptedResponse);
 

--- a/src/json-api-connection.ts
+++ b/src/json-api-connection.ts
@@ -8,6 +8,7 @@ import { JsonApiRequestInterceptor } from './json-api-request-interceptor';
 import { JsonApiResponseInterceptor } from './json-api-response-interceptor';
 import { DocumentObject } from './types/document-object';
 import { LinkObject } from './types/link-object';
+import { JsonApiFetchInterceptor } from './json-api-fetch-interceptor';
 
 /**
  * Represents a connection to json api.
@@ -29,6 +30,13 @@ export class JsonApiConnection
      * @type {JsonApiRequestInterceptor}
      */
     public readonly jsonApiRequestInterceptor: JsonApiRequestInterceptor;
+    
+    /**
+     * Json api fetch interceptor for adding additional behaviours.
+     * 
+     * @type {JsonApiFetchInterceptor}
+     */
+    public readonly jsonApiFetchInterceptor: JsonApiFetchInterceptor;
 
     /**
      * Json api response interceptor for adding additional behaviours.
@@ -54,11 +62,13 @@ export class JsonApiConnection
     public constructor(
         baseUrl: string, 
         jsonApiRequestInterceptor: JsonApiRequestInterceptor, 
+        jsonApiFetchInterceptor: JsonApiFetchInterceptor,
         jsonApiResponseInterceptor: JsonApiResponseInterceptor
     )
     {
         this.baseUrl = baseUrl.replace(new RegExp('\\/+$', 'g'), '');
         this.jsonApiRequestInterceptor = jsonApiRequestInterceptor;
+        this.jsonApiFetchInterceptor = jsonApiFetchInterceptor;
         this.jsonApiResponseInterceptor = jsonApiResponseInterceptor;
         this.headers = this.buildHeaders();
 
@@ -93,7 +103,7 @@ export class JsonApiConnection
         const headers = new Headers(this.headers);
         const request = new Request(href, { headers: headers, credentials: 'same-origin', method: 'GET' });
         const interceptedRequest = this.jsonApiRequestInterceptor(request);
-        const response = await fetch(interceptedRequest);
+        const response = await this.jsonApiFetchInterceptor(interceptedRequest);
         const interceptedResponse = this.jsonApiResponseInterceptor(response);
         const responseDocumentObject = await this.extractDocumentObject(interceptedResponse);
 

--- a/src/json-api-entity-provider-options.ts
+++ b/src/json-api-entity-provider-options.ts
@@ -1,3 +1,4 @@
+import { JsonApiFetchInterceptor } from './json-api-fetch-interceptor';
 import { JsonApiFilterExpressionVisitor } from './json-api-filter-expression-visitor';
 import { JsonApiMetadataExtractor } from './json-api-metadata-extractor';
 import { JsonApiPaginateExpressionVisitor } from './json-api-paginate-expression-visitor';
@@ -24,6 +25,13 @@ export interface JsonApiEntityProviderOptions
      * @type {JsonApiRequestInterceptor}
      */
     jsonApiRequestInterceptor?: JsonApiRequestInterceptor;
+
+    /**
+     * Json api fetch interceptor if any.
+     * 
+     * @type {JsonApiFetchInterceptor}
+     */
+    jsonApiFetchInterceptor?: JsonApiFetchInterceptor;
 
     /**
      * Json api response interceptor if any.

--- a/src/json-api-entity-provider.ts
+++ b/src/json-api-entity-provider.ts
@@ -15,6 +15,7 @@ import { jsonApiRelationshipPath } from './json-api-relationship-path';
 import { JsonApiSortExpressionVisitor } from './json-api-sort-expression-visitor';
 import { JsonApiToManyRelationship } from './json-api-to-many-relationship';
 import { JsonApiToOneRelationship } from './json-api-to-one-relationship';
+import fetch from 'cross-fetch';
 
 /**
  * Json api implementation of entity provider.
@@ -46,8 +47,10 @@ export class JsonApiEntityProvider implements EntityProvider
     {
         const defaultJsonApiRequestInterceptor = (request: Request) => request;
         const defaultJsonApiResponseInterceptor = (response: Response) => response;
+        const defaultJsonApiFetchInterceptor = fetch;
         const jsonApiRequestInterceptor = jsonApiEntityProviderOptions.jsonApiRequestInterceptor ?? defaultJsonApiRequestInterceptor;
         const jsonApiResponseInterceptor = jsonApiEntityProviderOptions.jsonApiResponseInterceptor ?? defaultJsonApiResponseInterceptor;
+        const jsonApiFetchInterceptor = jsonApiEntityProviderOptions.jsonApiFetchInterceptor ?? defaultJsonApiFetchInterceptor;
         const allowToManyRelationshipReplacement = jsonApiEntityProviderOptions.allowToManyRelationshipReplacement ?? false;
         const jsonApiMetadataExtractor = jsonApiEntityProviderOptions.jsonApiMetadataExtractor ?? new JsonApiMetadataExtractor();
         const jsonApiFilterExpressionVisitor = jsonApiEntityProviderOptions.jsonApiFilterExpressionVisitor ?? new JsonApiFilterExpressionVisitor();
@@ -55,7 +58,7 @@ export class JsonApiEntityProvider implements EntityProvider
         const jsonApiSortExpressionVisitor = new JsonApiSortExpressionVisitor();
         const jsonApiIncludeExpressionVisitor = new JsonApiIncludeExpressionVisitor();
         
-        this.jsonApiConnection = new JsonApiConnection(jsonApiEntityProviderOptions.baseUrl, jsonApiRequestInterceptor, jsonApiResponseInterceptor);
+        this.jsonApiConnection = new JsonApiConnection(jsonApiEntityProviderOptions.baseUrl, jsonApiRequestInterceptor, jsonApiFetchInterceptor, jsonApiResponseInterceptor);
         this.jsonApiAdapter = new JsonApiAdapter(this.jsonApiConnection, jsonApiMetadataExtractor, jsonApiFilterExpressionVisitor, jsonApiPaginateExpressionVisitor, jsonApiSortExpressionVisitor, jsonApiIncludeExpressionVisitor, allowToManyRelationshipReplacement);
 
         return;

--- a/src/json-api-fetch-interceptor.ts
+++ b/src/json-api-fetch-interceptor.ts
@@ -1,0 +1,7 @@
+/**
+ * Represents fetch interceptor to json api. May be used to add additional behaviours
+ * to the fetch api call, such as mocking.
+ * 
+ * @type {JsonApiFetchInterceptor}
+ */
+export type JsonApiFetchInterceptor = (request: Request) => Promise<Response>;


### PR DESCRIPTION
# Description

This adds an injection point for the Connector's fetch function. Useful for injecting mocks.

Implements  #25 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unfortunately, I am seeing some race conditions on the test codebase. Where if I inject a different function, it may or may not take. I think this must be due to some form of object storage preventing different instantiations of the `SpecEntityProvider`.

I did determine that the configuration option does work, I just can't get it to be conditionally enabled. Thus, I would need to rewrite all the existing tests to make a new test for this. Perhaps you could give me insight as to why the constructor may not be executed each time it is called?
- I might have an idea to implement conditional behavior using static variables, but I usually avoid those if I can.

## Checklist before requesting a review

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
