### PR TITLE
[Bulk] Save child entities under a parent entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ The To-Many relationship provider enables operations on to-many relationships. T
 4. Adding an element to the related data.
 5. Updating related data by pointing relationship to a different model.
 6. Removing an element from the related data.
+7. Saving non-root entities directly under their parent.
 
 ```typescript
 const userMessages = jsonApiEntityProvider.createJsonApiToManyRelationship(userSet, user, u => u.messages);
@@ -229,6 +230,10 @@ await userMessages.bulkUpdate(addedMessages);
 // Removing To-Many relationship data.
 await userMessages.remove(addedMessage);
 await userMessages.bulkRemove(toRemoveMessages);
+
+// Saving non-root element(s) directly to their related parent.
+await userMessages.save(newMessage);
+await userMessages.bulkSave(newMessages);
 ```
 
 ## Versioning

--- a/src/json-api-to-many-relationship-provider.ts
+++ b/src/json-api-to-many-relationship-provider.ts
@@ -173,7 +173,14 @@ export class JsonApiToManyRelationshipProvider implements EntityProvider
      */
     public async executeSaveCommand<TEntity extends Entity>(saveCommand: SaveCommand<TEntity>): Promise<TEntity>
     {
-        throw new CommandNotSupportedError(saveCommand, this);
+        const typeMetadata = saveCommand.entityInfo.typeMetadata;
+        const requestEntity = saveCommand.entity;
+        const requestRelationshipObject = this.jsonApiAdapter.createEntityDocumentObject(typeMetadata, requestEntity);
+        const linkObject = this.jsonApiAdapter.createRelationshipLinkObject(this.typeMetadata, this.entity, this.propertyMetadata, "");
+
+        await this.jsonApiConnection.post(linkObject, requestRelationshipObject);
+
+        return requestEntity;
     }
 
     /**
@@ -185,7 +192,14 @@ export class JsonApiToManyRelationshipProvider implements EntityProvider
      */
     public async executeBulkSaveCommand<TEntity extends Entity>(bulkSaveCommand: BulkSaveCommand<TEntity>): Promise<EntityCollection<TEntity>>
     {
-        throw new CommandNotSupportedError(bulkSaveCommand, this);
+        const typeMetadata = bulkSaveCommand.entityInfo.typeMetadata;
+        const requestEntityCollection = bulkSaveCommand.entityCollection;
+        const requestDocumentCollection = requestEntityCollection.map(el => this.jsonApiAdapter.createEntityDocumentObject(typeMetadata, el))
+        const linkObject = this.jsonApiAdapter.createRelationshipLinkObject(this.typeMetadata, this.entity, this.propertyMetadata, "");
+
+        await Promise.all(requestDocumentCollection.map(el => this.jsonApiConnection.post(linkObject, el)));
+
+        return requestEntityCollection;
     }
 
     /**


### PR DESCRIPTION
# Description

This PR is for allowing persisting child entities(non-root level entities) directly under a parent entity without having them in the datastore previously.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Have a root entity(`A`) and a non-root entity(`B`), `A` has a to-many relationship with `B`, create a `JsonApiToManyRelationship` for the corresponding relationship then hit save/bulkSave. The JSON:API server must persist all passed `B`s and attach them to `A`.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
