### PR TITLE
Expose save/bulk save methods in to-many relationship

### DIFF
--- a/src/json-api-to-many-relationship.ts
+++ b/src/json-api-to-many-relationship.ts
@@ -246,4 +246,28 @@ export class JsonApiToManyRelationship<TEntity extends Entity, TRelationship ext
     {
         return this.relationshipSet.bulkRemove(relationshipCollectionLike);
     }
+    
+    /**
+     * Saves a child entity.
+     *
+     * @param {TRelationship} relationship Child entity to be saved.
+     *
+     * @returns {Promise<TRelationship>} Saved entity.
+     */
+    public save(relationship: TRelationship): Promise<TRelationship>
+    {
+        return this.relationshipSet.save(relationship);
+    }
+
+    /**
+     * Bulk saves a child entities collection.
+     *
+     * @param {EntityCollectionLike<TRelationship>} relationshipCollectionLike Child entities collection to be saved.
+     *
+     * @returns {Promise<EntityCollection<TRelationship>>} Saved entity collection.
+     */
+    public bulkSave(relationshipCollectionLike: EntityCollectionLike<TRelationship>): Promise<EntityCollection<TRelationship>>
+    {
+        return this.relationshipSet.bulkSave(relationshipCollectionLike);
+    }
 }


### PR DESCRIPTION
# Description

Add save and bulk save methods in to-many relationship which hits the save and bulk save methods in to-many relationship provider.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Create a to-many relationship provider and call `save` and `bulkSave` method, it should call the provider's `executeSaveCommand` and `executeBulkSaveCommand` respectively.

- [x] Create a to-many relationship provider and call `save` method, it should call the provider's `executeSaveCommand` method.
- [x] Create a to-many relationship provider and call `bulkSave` method, it should call the provider's `executeBulkSaveCommand` method.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
